### PR TITLE
Fix that the parameter filename_mtl is ignored

### DIFF
--- a/pyvista/plotting/plotter.py
+++ b/pyvista/plotting/plotter.py
@@ -587,7 +587,10 @@ class BasePlotter(PickingHelper, WidgetHelper):
         # lazy import here to avoid importing unused modules
         importer = vtkOBJImporter()
         importer.SetFileName(filename)
-        filename_mtl = filename.with_suffix('.mtl')
+        if filename_mtl is not None:
+            filename_mtl = Path(filename_mtl).expanduser().resolve()
+        else:
+            filename_mtl = filename.with_suffix('.mtl')
         if filename_mtl.is_file():
             importer.SetFileNameMTL(filename_mtl)
             importer.SetTexturePath(filename_mtl.parents[0])


### PR DESCRIPTION
Fix that the parameter filename_mtl is ignored

### Overview

The plotter.py takes a optional parameter called filename_mtl, but with the current logic that parameter is ignored. The PR fixes this bug.
